### PR TITLE
Testing Return Early

### DIFF
--- a/src/generator.rs
+++ b/src/generator.rs
@@ -5,7 +5,7 @@ use rand::Rng;
 
 use crate::board::{Board, GameState};
 use crate::field::FieldState;
-use crate::solver::Solver;
+use crate::solver::{Solver, SolverOptions};
 
 pub(crate) trait Generator {
     fn generate_field(&self, board: &mut Board, start_x: usize, start_z: usize);
@@ -120,7 +120,13 @@ impl Generator for NoGuessing {
 
             board.open_field(start_x, start_z);
 
-            let mut solver = Solver::new(board);
+            let mut solver = Solver::new(
+                board,
+                SolverOptions {
+                    skip_complex_fields: true,
+                    complex_field_threshold: 25,
+                },
+            );
 
             //Since board is borrowed at this point inside Solver I have to use solver.board instead of just board
             while solver.board.game_state == GameState::Playing {

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -14,6 +14,12 @@ pub(crate) struct Solver<'a> {
     known_mines: Vec<Vec<bool>>,
     known_empty: Vec<Vec<bool>>,
     tank_solutions: Vec<Vec<bool>>,
+    options: SolverOptions,
+}
+
+pub(crate) struct SolverOptions {
+    pub(crate) skip_complex_fields: bool,
+    pub(crate) complex_field_threshold: usize,
 }
 
 #[derive(PartialEq)]
@@ -23,7 +29,7 @@ enum InteractAction {
 }
 
 impl Solver<'_> {
-    pub(crate) fn new(board: &mut Board) -> Solver {
+    pub(crate) fn new(board: &mut Board, options: SolverOptions) -> Solver {
         Solver {
             board,
             made_changes: false,
@@ -34,6 +40,7 @@ impl Solver<'_> {
             known_mines: Vec::new(),
             known_empty: Vec::new(),
             tank_solutions: Vec::new(),
+            options,
         }
     }
 
@@ -156,7 +163,9 @@ impl Solver<'_> {
     }
 
     fn tank_recurse(&mut self, border_tiles: &Vec<(usize, usize)>, depth: usize) {
-        if border_tiles.len() > 25 {
+        if self.options.skip_complex_fields
+            && border_tiles.len() > self.options.complex_field_threshold
+        {
             println!("Stopping early, too many borders");
             return;
         }

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -156,6 +156,10 @@ impl Solver<'_> {
     }
 
     fn tank_recurse(&mut self, border_tiles: &Vec<(usize, usize)>, depth: usize) {
+        if border_tiles.len() > 25 {
+            println!("Stopping early, too many borders");
+            return;
+        }
         let mut flag_count = 0;
         for x in 0..self.board.x_size {
             for z in 0..self.board.z_size {


### PR DESCRIPTION
This would speed up the finding of fields in most cases, since the algorithm skips fields which take long to solve and instead spends the time generating a new field which might be faster to solve.

I might have to make this optional to allow for field solving without generating, and to give the user the option.